### PR TITLE
Add word wrap toggle and misc improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ iOSInjectionProject/
 .env.development
 .env.test
 .env.production
+.claude/

--- a/ScribblePad/Controllers/PersistenceController.swift
+++ b/ScribblePad/Controllers/PersistenceController.swift
@@ -31,8 +31,13 @@ class PersistenceController {
         modificationDateAttribute.name = "modificationDate"
         modificationDateAttribute.attributeType = .dateAttributeType
         
+        let wordWrapAttribute = NSAttributeDescription()
+        wordWrapAttribute.name = "isWordWrapEnabled"
+        wordWrapAttribute.attributeType = .booleanAttributeType
+        wordWrapAttribute.defaultValue = true
+        
         // Add attributes to entity
-        noteEntity.properties = [idAttribute, contentAttribute, creationDateAttribute, modificationDateAttribute]
+        noteEntity.properties = [idAttribute, contentAttribute, creationDateAttribute, modificationDateAttribute, wordWrapAttribute]
         
         // Create model with entity
         let model = NSManagedObjectModel()
@@ -72,6 +77,7 @@ class PersistenceController {
         newNote.content = ""
         newNote.creationDate = Date()
         newNote.modificationDate = Date()
+        newNote.isWordWrapEnabled = true // Default to word wrap ON
         saveContext()
         return newNote
     }

--- a/ScribblePad/Entities/Note.swift
+++ b/ScribblePad/Entities/Note.swift
@@ -13,6 +13,7 @@ class Note: NSManagedObject, Identifiable {
     @NSManaged public var content: String?
     @NSManaged public var creationDate: Date?
     @NSManaged public var modificationDate: Date?
+    @NSManaged public var isWordWrapEnabled: Bool
     
     var noteTitle: String {
         let firstLine = content?.split(separator: "\n").first ?? ""

--- a/ScribblePad/ScribbleAppDelegate.swift
+++ b/ScribblePad/ScribbleAppDelegate.swift
@@ -2,7 +2,6 @@ import Foundation
 import SwiftUI
 
 
-
 // MARK: - App Delegate for Menu Handling
 class ScribbleAppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem?
@@ -15,20 +14,18 @@ class ScribbleAppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func setupStatusBarItem() {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         
         if let button = statusItem?.button {
-            //button.title = "S"
-            //button.font = NSFont.boldSystemFont(ofSize: 15)
-            let symbolConfig = NSImage.SymbolConfiguration(pointSize: 16, weight: .medium)
-                    button.image = NSImage(systemSymbolName: "doc.circle", accessibilityDescription: "ScribblePad")?
-                        .withSymbolConfiguration(symbolConfig)
+            button.title = "📝"
+            button.font = NSFont.systemFont(ofSize: 16)
             button.action = #selector(statusBarButtonClicked)
             button.target = self
         }
     }
     
     @objc func statusBarButtonClicked() {
+        // Show/hide app window
         if let window = NSApp.windows.first {
             if window.isVisible {
                 // If window is already visible, just bring it to front
@@ -66,3 +63,4 @@ class ScribbleAppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 }
+

--- a/ScribblePad/Views/ContentView.swift
+++ b/ScribblePad/Views/ContentView.swift
@@ -99,8 +99,17 @@ struct ContentView: View {
         
         // Status Bar
         StatusBarView(
+            documentCreationDate: selectedNote?.creationDate,
             documentModificationDate: selectedNote?.modificationDate,
-            documentContent: selectedNote?.content
+            documentContent: selectedNote?.content,
+            isWordWrapEnabled: selectedNote?.isWordWrapEnabled ?? true,
+            onWordWrapToggle: {
+                if let note = selectedNote {
+                    note.isWordWrapEnabled.toggle()
+                    note.modificationDate = Date()
+                    PersistenceController.shared.saveContext()
+                }
+            }
         )
     }
     }

--- a/ScribblePad/Views/NoteDetailView.swift
+++ b/ScribblePad/Views/NoteDetailView.swift
@@ -9,7 +9,8 @@ struct NoteDetailView: View {
     var body: some View {
         TextEditor(
             text: $tempContent,
-            font: NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize + 1, weight: .regular)
+            font: NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize + 1, weight: .regular),
+            isWordWrapEnabled: note.isWordWrapEnabled
         )
         .onAppear {
             // Set the content when the view appears

--- a/ScribblePad/Views/StatusBarView.swift
+++ b/ScribblePad/Views/StatusBarView.swift
@@ -7,6 +7,8 @@ struct StatusBarView: View {
     var documentCreationDate: Date?
     var documentModificationDate: Date?
     var documentContent: String?
+    var isWordWrapEnabled: Bool
+    var onWordWrapToggle: () -> Void
     
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -52,8 +54,22 @@ struct StatusBarView: View {
                     
                     Divider()
                         .frame(height: 12)
-                        .padding(.horizontal, 8)
                 }
+                
+                // Word wrap toggle
+                HStack(spacing: 4) {
+                    Text("Word wrap:")
+                        .foregroundColor(.secondary)
+                    Toggle("", isOn: Binding(
+                        get: { isWordWrapEnabled },
+                        set: { _ in onWordWrapToggle() }
+                    ))
+                    .toggleStyle(SwitchToggleStyle(tint: .accentColor))
+                    .scaleEffect(0.8)
+                }
+                
+                Divider()
+                    .frame(height: 12)
                 
                 // Document dates
                 if let created = documentCreationDate {

--- a/ScribblePad/Views/TextEditor.swift
+++ b/ScribblePad/Views/TextEditor.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct TextEditor: NSViewRepresentable {
     @Binding var text: String
     var font: NSFont
+    var isWordWrapEnabled: Bool
     
     func makeNSView(context: Context) -> NSScrollView {
         // Create a scroll view and text view
@@ -23,14 +24,8 @@ struct TextEditor: NSViewRepresentable {
         textView.textColor = NSColor.black
         textView.insertionPointColor = NSColor.black
         textView.drawsBackground = true
-        textView.isHorizontallyResizable = false
-        textView.isVerticallyResizable = true
-        textView.autoresizingMask = [.width]
-        textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.containerSize = NSSize(
-            width: scrollView.contentSize.width,
-            height: CGFloat.greatestFiniteMagnitude
-        )
+        // Configure word wrap based on state
+        configureWordWrap(textView: textView, scrollView: scrollView, enabled: isWordWrapEnabled)
         
         // Set text
         textView.string = text
@@ -64,6 +59,8 @@ struct TextEditor: NSViewRepresentable {
         // Add border
         scrollView.borderType = .bezelBorder
         
+        // Word wrap configuration is now handled via parameter updates
+        
         return scrollView
     }
     
@@ -77,6 +74,9 @@ struct TextEditor: NSViewRepresentable {
             textView.string = text
         }
         
+        // Update word wrap configuration if needed
+        configureWordWrap(textView: textView, scrollView: nsView, enabled: isWordWrapEnabled)
+        
         // Make sure the ruler is visible and has correct thickness
         if !nsView.rulersVisible {
             nsView.rulersVisible = true
@@ -88,6 +88,58 @@ struct TextEditor: NSViewRepresentable {
                 print("🔍 DEBUG: Correcting ruler thickness from \(rulerView.ruleThickness) to 40.0")
                 rulerView.ruleThickness = 40.0
             }
+        }
+    }
+    
+    private func configureWordWrap(textView: NSTextView, scrollView: NSScrollView, enabled: Bool) {
+        if enabled {
+            // Enable word wrap
+            textView.isHorizontallyResizable = false
+            textView.isVerticallyResizable = true
+            textView.autoresizingMask = [.width]
+            textView.textContainer?.widthTracksTextView = true
+            // Don't set container width explicitly - let widthTracksTextView handle it
+            // This ensures the text view frame (which accounts for the ruler) is used
+            textView.textContainer?.containerSize = NSSize(
+                width: textView.frame.width,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            scrollView.hasHorizontalScroller = false
+            scrollView.autohidesScrollers = true
+        } else {
+            // Disable word wrap - allow horizontal scrolling
+            textView.isHorizontallyResizable = true
+            textView.isVerticallyResizable = true
+            textView.autoresizingMask = []
+            textView.textContainer?.widthTracksTextView = false
+            textView.textContainer?.containerSize = NSSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            scrollView.hasHorizontalScroller = true
+            scrollView.hasVerticalScroller = true
+            scrollView.autohidesScrollers = false
+            
+            // Configure text view for unlimited horizontal scrolling
+            textView.minSize = NSSize(width: 0, height: 0)
+            textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+            
+            // Force the text view to resize to accommodate all content
+            textView.sizeToFit()
+            
+            // Ensure the text container has no width constraints
+            textView.textContainer?.lineFragmentPadding = 0
+        }
+        
+        // Force layout update and refresh scrollers
+        textView.layoutManager?.ensureLayout(for: textView.textContainer!)
+        scrollView.tile()
+        textView.needsDisplay = true
+        scrollView.flashScrollers()
+        
+        // Refresh line numbers after word wrap change
+        if let rulerView = scrollView.verticalRulerView {
+            rulerView.needsDisplay = true
         }
     }
     


### PR DESCRIPTION
## Summary
- Add per-note word wrap toggle feature with status bar UI
- Fix text container width calculation to account for line number ruler
- Update status bar icon to use emoji
- Add .claude/ to gitignore

## Test plan
- [ ] Toggle word wrap on/off for a note and verify text wraps correctly
- [ ] Edit text with word wrap enabled and confirm it stays within window bounds
- [ ] Verify word wrap setting persists per-note after app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)